### PR TITLE
fixed return codes and error handling

### DIFF
--- a/src/quickslurm/data.py
+++ b/src/quickslurm/data.py
@@ -15,6 +15,8 @@ class CommandResult:
 @dataclass(frozen=True)
 class SubmitResult:
     job_id: int
+    state: str
+    returncode: int
     stdout: str
     stderr: str
     args: List[str]

--- a/src/quickslurm/utils.py
+++ b/src/quickslurm/utils.py
@@ -20,10 +20,6 @@ class SlurmCommandError(SlurmError):
         self.result = result
 
 
-class SlurmParseError(SlurmError):
-    pass
-
-
 # ----------------- Helpers -----------------
 _JOB_ID_RE = re.compile(r"Submitted batch job\s+(\d+)")
 
@@ -127,20 +123,11 @@ def _slurm_wait(job_id) -> None:
 
 def _parse_result(job_id):
     try:
-        res = sacct_cmd(job_id, ops='JobID,State,ExitCode,StdOut,StdErr')
+        res = sacct_cmd(job_id, ops='State,ExitCode,StdOut,StdErr')
     except Exception as e:
         print(f'Warning: Failed to check exit status of job! {e}')
-        return -1
-    print(f'Check response: {res}')
-    j_id, state, exit_code = res.stdout.strip().split()[:3]
-    print(f'ID: {j_id} | State: {state} | Exit: {exit_code}')
-
-    if state == 'COMPLETED':
-        return 0
-    elif state == 'FAILED':
-        return 1
-    else: 
-        return 2
+        return "UNKNOWN", 0, 'UNKNOWN', 'UNKNOWN'
+    return res.stdout.strip().split()[:4]
 
 # ----------------- Convenience preset -----------------
 
@@ -165,18 +152,3 @@ def default_gpu_options(
         opts["cpus-per-task"] = cpus_per_task
     return opts
 
-def read_cfg_file(cfg_path):
-    """
-    Reads a .cfg file and returns all key-value pairs as a dictionary.
-    """
-    from configparser import ConfigParser
-    config = ConfigParser()
-    config.read(cfg_path)
-    
-    # Flatten into a single dict: { "section.key": value }
-    cfg_dict = {}
-    for section in config.sections():
-        if section == 'quickslurm':
-            cfg_dict = config.items(section)
-    
-    return cfg_dict

--- a/src/quickslurm/utils.py
+++ b/src/quickslurm/utils.py
@@ -20,6 +20,10 @@ class SlurmCommandError(SlurmError):
         self.result = result
 
 
+class SlurmParseError(SlurmError):
+    pass
+
+
 # ----------------- Helpers -----------------
 _JOB_ID_RE = re.compile(r"Submitted batch job\s+(\d+)")
 


### PR DESCRIPTION
Fixed `SubmitResult`:
 - added more complete return values (job_id, state, return_code, std_out, std_err, args)
 - parse `sacct` output instead of passing subprocess return value (unreliable)

Error handling:
- check enabled will throw a `SlurmParseError` if calling subprocess fails
- no check will return default values and subprocess return values of calling subprocess (not recommended)
- should have a try except to restart job if `SlurmParseError` is encountered

Logic changes:
- All working results return a `SubmitResult`
- `CommandResult` is strictly for errors
- Removed default config - too many overwriting issues

MISC:
- fixed `sbatch` return scheme so that it will always return `SubmitResult` or raise an error based on input settings
- general cleaning and refactoring